### PR TITLE
Improved port definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,50 @@
-## Fwd2Me
+# Fwd2Me
 
-Fwd2Me - really simple UPnP port forwarding for Linux
+Fwd2Me - really simple UPnP port forwarding
 
-### Usage
+## Usage
 
 ```shell
 $ fwd2me --help
-Usage of fwd2me [options] [port1 port2 ...]:
+Usage of fwd2me [options] port1[:remote[:proto]] port2 ...:
   -label string
-    	Label for the forwarding (default "fwd2me")
+        Label for the forwarding (default "fwd2me")
   -proto string
-    	Forwarded port protocol (default "TCP")
+        Default forwarded port protocol (default "TCP")
 ```
 
-### Example
+## Example
+
+### Symmetrical, TCP
 
 ```shell
 $ fwd2me 80 443
 Recreating forwarding from 46.164.xxx.xx to 192.168.1.76
-Port 80 forwarded
-Port 443 forwarded
+Port forwarding created: internal (80), external (80), proto (TCP)
+Port forwarding created: internal (443), external (443), proto (TCP)
 ```
 
+### Symmetrical, UDP
+
+```shell
+$ fwd2me -proto UDP 62332
+Recreating forwarding from 46.164.xxx.xx to 192.168.1.76
+Port forwarding created: internal (62332), external (62332), proto (UDP)
+```
+
+### Assymetrical, TCP
+
+```shell
+$ fwd2me 16080:80
+Recreating forwarding from 46.164.xxx.xx to 192.168.1.76
+Port forwarding created: internal (16080), external (80), proto (TCP)
+```
+
+
+### Assymetrical, UDP
+
+```shell
+$ fwd2me 65101:51101:UDP
+Recreating forwarding from 46.164.xxx.xx to 192.168.1.76
+Port forwarding created: internal (65101), external (51101), proto (UDP)
+```

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -11,12 +12,16 @@ import (
 
 var (
 	proto = flag.String("proto", "TCP", "Forwarded port protocol")
-	label = flag.String("label", "fwd2me", "Label for the forwarding")
+	label = flag.String("label", "fwd2me", "Label for the forwarding shown in router menu")
 )
 
 func main() {
 	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s [options] [port1 port2 ...]:\n", os.Args[0])
+		fmt.Fprintf(
+			flag.CommandLine.Output(),
+			"Usage of %s [options] port1[:external[:proto]] port2 ...:\n",
+			os.Args[0],
+		)
 		flag.PrintDefaults()
 	}
 
@@ -33,7 +38,7 @@ func main() {
 		cancel()
 	}()
 
-	if err := keepForwarded(ctx); err != nil {
+	if err := keepForwarded(ctx); err != nil && !errors.Is(err, errEmptyPortList) {
 		_, _ = fmt.Fprintln(os.Stderr, err.Error())
 
 		os.Exit(1)


### PR DESCRIPTION
Add support setting external port and protocol per forwarded port
Supported syntax: `fwd2me <internal>:<external>:<proto>`